### PR TITLE
Fixes OSX Build issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ else ()
 endif()
 
 set (CMAKE_CXX_FLAGS "${CPP11_FLAGS} -Wall")
-include_directories(/usr/local/Cellar/boost/1.52.0/include)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 # Library Sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,16 @@ project(Skald)
 # Set relative link path base to source directory
 cmake_policy(SET CMP0015 NEW)
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set (CPP11_FLAGS "-std=c++11 -stdlib=libc++")
+else ()
+    set (CPP11_FLAGS "-std=c++11")
+endif()
+
+set (CMAKE_CXX_FLAGS "${CPP11_FLAGS} -Wall")
+include_directories(/usr/local/Cellar/boost/1.52.0/include)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+
 # Library Sources
 set (${PROJECT_NAME}_SOURCES
     src/Component.hpp
@@ -40,8 +50,6 @@ set (${PROJECT_NAME}_TEST_SOURCES
 )
 
 # Test Build Rules
-set (CMAKE_CXX_FLAGS "-std=c++11 -Wall")
-include_directories(${CMAKE_SOURCE_DIR}/src)
 add_executable(testrunner ${${PROJECT_NAME}_TEST_SOURCES})
-target_link_libraries(testrunner gtest gtest_main)
+target_link_libraries(testrunner gtest_main gtest )
 add_test(testrunner testrunner)

--- a/src/EntityManager.hpp
+++ b/src/EntityManager.hpp
@@ -3,7 +3,7 @@
 #define SKALD_ENTITY_MANAGER_HPP
 #include <cassert>
 #include <bitset>
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 #include <array>
 #include <utility>

--- a/src/World.hpp
+++ b/src/World.hpp
@@ -34,7 +34,7 @@ public:
 
 	template<class T>
 	inline void removeComponent(const entityID e){
-		entities.removeComponent<T>(e);
+		entities.template removeComponent<T>(e);
 	}
 
 	inline void addSystem(const SystemPtr s){


### PR DESCRIPTION
CMakeLists.txt changes:
- Moved compiler configuration above gtest include
- Forced libc++ when building with clang

src/EntityManager.hpp changes:
- Switched stdint include string -- clang likes this one better.

src/World.hpp
- Members requiring a template argument need the template keyword
  after the . or -> and before the member symbol.

All tests now pass on OSX with the following build process:

```
mkdir build && cd build && cmake .. && cmake --build . && ./testrunner
```
